### PR TITLE
Fix start entry to use index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "nodejs-blog-app",
   "version": "1.0.0",
   "description": "Blog application using Node.js and MongoDB with authentication using JWT",
-  "main": "app.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon app.js"
+    "start": "nodemon index.js"
   },
   "author": "Harshit Rathod",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- use `index.js` as `main`
- update start script to run `nodemon index.js`

## Testing
- `npm start` *(fails: nodemon not found)*
- `node index.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684c24d96bfc832a82b163255dcbc4fb