### PR TITLE
Fix photo-details route access

### DIFF
--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -17,6 +17,7 @@ router.get('/dashboard', requireAuth, blogController.get_dashboard);
 router.post('/upload', upload.single('photo'), blogController.post_upload);
 router.post('/upload-multiple', upload.array('images', 1000), blogController.post_uploadMultiple);
 router.get('/profile', requireAuth, blogController.get_profile);
+// The photo details page is accessible to any authenticated user, including admins.
 router.get('/photo-details', requireAuth, blogController.get_postData);
 router.get('/admin/dashboard/hashtags',requireAuth, blogController.get_adminHashtags);
 
@@ -24,7 +25,6 @@ router.get('/admin/dashboard/hashtags',requireAuth, blogController.get_adminHash
 
 router.get('/admin/dashboard', requireAdmin, blogController.get_adminDashboard);
 router.get('/admin/dashboard/photos',requireAdmin, blogController.get_adminPhotos);
-router.get('/photo-details', requireAdmin, blogController.get_postData);
 router.get('/admin/dashboard/hashtags',requireAdmin, blogController.get_adminHashtags);
 
 


### PR DESCRIPTION
## Summary
- remove duplicated `/photo-details` route that only admins could use
- clarify that `/photo-details` is available to any authenticated user

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c24db638c832a92be656f7ab972a0