### PR TITLE
Remove redundant body-parser middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const authRoutes = require('./routes/authRoutes');
 const blogRoutes = require('./routes/blogRoutes');
 const cookieParser = require('cookie-parser');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
-const bodyParser = require('body-parser');
 
 const app = express();
 
@@ -16,7 +15,6 @@ app.use(cookieParser());
 app.use("/css", express.static(path.join(__dirname, "node_modules/bootstrap/dist/css")))
 app.use("/bootstrap", express.static(path.join(__dirname, "node_modules/bootstrap/dist/js")))
 app.use("/jquery", express.static(path.join(__dirname, "node_modules/jquery/dist")))
-app.use(bodyParser.urlencoded({ extended: true }));
 
 // view engine
 app.set('view engine', 'ejs');


### PR DESCRIPTION
## Summary
- rely on `express.urlencoded` for URL encoded forms
- remove unused `body-parser` setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c24de017c832aa9441538a602a0c2