### PR TITLE
Fix duplicate hashtag route

### DIFF
--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -19,7 +19,6 @@ router.post('/upload-multiple', upload.array('images', 1000), blogController.pos
 router.get('/profile', requireAuth, blogController.get_profile);
 // The photo details page is accessible to any authenticated user, including admins.
 router.get('/photo-details', requireAuth, blogController.get_postData);
-router.get('/admin/dashboard/hashtags',requireAuth, blogController.get_adminHashtags);
 
 //Admin Routes
 


### PR DESCRIPTION
## Summary
- remove redundant route for `/admin/dashboard/hashtags`
- verify routes are unique

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c32b99b4c832a81e1d77ef6d9d7a1