### PR TITLE
Enable admin emails via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Ensure these files contain your own credentials before starting the application.
    npm install
    ```
 2. (Optional) set the `PORT` environment variable to control the server port. If not set, the app defaults to port `8080`.
-3. Start the server:
+3. (Optional) set `ADMIN_EMAILS` to a comma-separated list of addresses that should have admin access.
+4. Start the server:
    ```bash
    node index.js
    ```

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,5 +1,11 @@
 const admin = require('firebase-admin');
 
+// list of admin emails supplied via environment variable
+const adminEmails = (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((e) => e.trim())
+    .filter(Boolean);
+
 const requireAuth = (req, res, next) => {
     const sessionCookie = req.cookies.session || '';
 
@@ -47,7 +53,7 @@ const checkUser = async (req, res, next) => {
     try {
         const decodedClaims = await admin.auth().verifySessionCookie(token, true);
         res.locals.user = decodedClaims;
-        if(res.locals.user.email === "1991anirudh@gmail.com"){
+        if (adminEmails.includes(res.locals.user.email)) {
             res.locals.isAdmin = true;
         }
         next();


### PR DESCRIPTION
## Summary
- get admin email list from `ADMIN_EMAILS` env var in `authMiddleware`
- document the `ADMIN_EMAILS` variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c32bb38b0832ab2f5ad398437c34a