### PR TITLE
Add hashtag stats and creation modal

### DIFF
--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -19,6 +19,8 @@ router.post('/upload-multiple', upload.array('images', 1000), blogController.pos
 router.get('/profile', requireAuth, blogController.get_profile);
 // The photo details page is accessible to any authenticated user, including admins.
 router.get('/photo-details', requireAuth, blogController.get_postData);
+router.get('/hashtags/:title', blogController.get_hashtag);
+router.post('/hashtags', requireAdmin, blogController.post_hashtag);
 
 //Admin Routes
 

--- a/views/admin/adminHashtags.ejs
+++ b/views/admin/adminHashtags.ejs
@@ -1,5 +1,8 @@
 <%- include('../partials/header'); -%>
 
+<div class="d-flex">
+  <%- include('../partials/sidebar'); -%>
+  <div class="flex-grow-1">
 <div class="container mt-4">
     <div class="pb-3 mb-3 d-flex border-bottom">
         <h4 class="m-0 p-0 me-1">All Hashtags</h4>
@@ -20,7 +23,7 @@
                     <path d="M1 3.5A1.5 1.5 0 0 1 2.5 2h2.764c.958 0 1.76.56 2.311 1.184C7.985 3.648 8.48 4 9 4h4.5A1.5 1.5 0 0 1 15 5.5v.64c.57.265.94.876.856 1.546l-.64 5.124A2.5 2.5 0 0 1 12.733 15H3.266a2.5 2.5 0 0 1-2.481-2.19l-.64-5.124A1.5 1.5 0 0 1 1 6.14zM2 6h12v-.5a.5.5 0 0 0-.5-.5H9c-.964 0-1.71-.629-2.174-1.154C6.374 3.334 5.82 3 5.264 3H2.5a.5.5 0 0 0-.5.5zm-.367 1a.5.5 0 0 0-.496.562l.64 5.124A1.5 1.5 0 0 0 3.266 14h9.468a1.5 1.5 0 0 0 1.489-1.314l.64-5.124A.5.5 0 0 0 14.367 7H1.633z"/>
                   </svg>
                 <div class="card-body">
-                    <h5 class="card-title" style="font-variant-caps: all-petite-caps; font-weight: 900; font-size: xx-large;"><%= datas[i].title %></h5>
+                    <h5 class="card-title" style="font-variant-caps: all-petite-caps; font-weight: 900; font-size: xx-large;"><a href="/hashtags/<%= datas[i].title %>">#<%= datas[i].title %></a></h5>
                     <p class="card-text"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-images" viewBox="0 0 16 16">
                         <path d="M4.502 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3"/>
                         <path d="M14.002 13a2 2 0 0 1-2 2h-10a2 2 0 0 1-2-2V5A2 2 0 0 1 2 3a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v8a2 2 0 0 1-1.998 2M14 2H4a1 1 0 0 0-1 1h9.002a2 2 0 0 1 2 2v7A1 1 0 0 0 15 11V3a1 1 0 0 0-1-1M2.002 4a1 1 0 0 0-1 1v8l2.646-2.354a.5.5 0 0 1 .63-.062l2.66 1.773 3.71-3.71a.5.5 0 0 1 .577-.094l1.777 1.947V5a1 1 0 0 0-1-1h-10"/>
@@ -86,6 +89,7 @@
             });
         });
     </script>
+  </div>
 </div>
 
 <%- include('../partials/footer'); -%>

--- a/views/hashtag.ejs
+++ b/views/hashtag.ejs
@@ -1,28 +1,22 @@
 <%- include('partials/header'); -%>
 
 <div class="pb-3 mb-3 d-flex border-bottom container">
-    <h4 class="m-0 p-0 me-1">All Photos</h4>
-    <h5 class="m-0 p-0"> (<span id="totalCount"><%= count %></span>)</h5>
+    <h4 class="m-0 p-0 me-1">#<%= hashtag && hashtag.title ? hashtag.title : title %></h4>
+    <h5 class="m-0 p-0"> (<%= images.length %>)</h5>
 </div>
-
+<div class="container mb-3">
+    <% if (hashtag) { %>
+    <p>Total Photos: <%= hashtag.count %></p>
+    <p>Total Worth Locked: <%= hashtag.utilityTokensLocked %></p>
+    <p>Average Photo Worth: <%= hashtag.avgPrice %></p>
+    <% } %>
+</div>
 <div class="container">
     <div class="row" id="cardContainer">
-        <% for (let i = 0; i < datas.length; i++) { %>
+        <% for (let i = 0; i < images.length; i++) { %>
         <div class="col-md-4 mb-4 <%= i >= 12 ? 'd-none' : '' %>">
             <div class="card">
-                <img src="<%= datas[i].imageUrl %>" class="card-img-top" alt="...">
-                <div class="card-body">
-                    <h5 class="card-title">Hashtags</h5>
-                    <p class="card-text">
-                        <% if (Array.isArray(datas[i].hashtags)) { %>
-                        <% for (let hashtag of datas[i].hashtags) { %>
-                        <a href="/hashtags/<%= hashtag %>" class="badge bg-primary me-1">#<%= hashtag %></a>
-                        <% } %>
-                        <% } %>
-                    </p>
-                    <p class="card-text">Exposure Value: <%= datas[i].ev %></p>
-                    <p class="card-text">Photo Value: <%= datas[i].sp %></p>
-                </div>
+                <img src="<%= images[i] %>" class="card-img-top" alt="...">
             </div>
         </div>
         <% } %>
@@ -33,12 +27,13 @@
 </div>
 
 <%- include('partials/footer'); -%>
-
 <script>
     const loadMoreBtn = document.getElementById('loadMoreBtn');
-    let startIndex = 12; // Tracks the starting index of hidden images
+    let startIndex = 12;
     const hiddenCards = document.querySelectorAll('.col-md-4.d-none');
-
+    if(hiddenCards.length <= 12){
+        loadMoreBtn.style.display = 'none';
+    }
     loadMoreBtn.addEventListener('click', () => {
         let count = 0;
         for (let i = startIndex; i < hiddenCards.length && count < 100; i++) {
@@ -46,7 +41,6 @@
             count++;
         }
         startIndex += count;
-
         if (startIndex >= hiddenCards.length) {
             loadMoreBtn.style.display = 'none';
         }

--- a/views/partials/sidebar.ejs
+++ b/views/partials/sidebar.ejs
@@ -1,0 +1,36 @@
+<div class="d-flex flex-column p-3 bg-light" style="width: 200px; min-height: 100vh;">
+  <ul class="nav nav-pills flex-column mb-auto">
+    <li class="nav-item mb-2">
+      <button class="btn btn-primary w-100" data-bs-toggle="modal" data-bs-target="#newHashtagModal">New Hashtag</button>
+    </li>
+  </ul>
+</div>
+
+<div class="modal fade" id="newHashtagModal" tabindex="-1" aria-labelledby="newHashtagModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" action="/hashtags" method="POST">
+      <div class="modal-header">
+        <h5 class="modal-title" id="newHashtagModalLabel">Create Hashtag</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="hashtagTitle" class="form-label">Title</label>
+          <input type="text" class="form-control" id="hashtagTitle" name="title" required>
+        </div>
+        <div class="mb-3">
+          <label for="hashtagValue" class="form-label">Desired Mean</label>
+          <input type="number" step="any" class="form-control" id="hashtagValue" name="value" required>
+        </div>
+        <div class="mb-3">
+          <label for="hashtagImage" class="form-label">Image URL</label>
+          <input type="text" class="form-control" id="hashtagImage" name="imageUrl">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add routes to show and create hashtags
- implement controller actions for hashtag gallery and creation
- link hashtags in gallery and admin pages to new hashtag view
- include sidebar with 'New Hashtag' modal on admin hashtags page
- create hashtag view with pagination

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c36dc6500832a8fb29624f702074e