### PR TITLE
Remove admin dashboard debug comment

### DIFF
--- a/views/admin/adminDashboard.ejs
+++ b/views/admin/adminDashboard.ejs
@@ -61,7 +61,6 @@
                     <% } %>
                 </tbody>
             </table>
-<!-- admin/adminDashboard.ejs -->
 
 <!-- Add this line to create a container for the chart -->
 <div class="chart-container" >


### PR DESCRIPTION
## Summary
- remove leftover debug comment from the admin dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c533184832abeb79980a843f6ac