### PR TITLE
Add Jest testing for dashboard

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ app.use(blogRoutes);
 
 
 const PORT = process.env.PORT || 8080;
-app.listen(PORT, () => {
-    console.log(`App is listening on ${PORT}`)
-})
+if (process.env.NODE_ENV !== 'test') {
+    app.listen(PORT, () => {
+        console.log(`App is listening on ${PORT}`)
+    });
+}
+
+module.exports = app;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Blog application using Node.js and MongoDB with authentication using JWT",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "nodemon index.js"
   },
   "author": "Harshit Rathod",
@@ -13,7 +13,9 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,17 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  requireAuth: (req, res, next) => next(),
+  checkUser: (req, res, next) => next(),
+  requireAdmin: (req, res, next) => next(),
+}));
+
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /dashboard', () => {
+  it('should return 200', async () => {
+    const res = await request(app).get('/dashboard');
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- export the Express app and only listen when not testing
- configure Jest and Supertest
- add a basic dashboard route test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c55cd78832a812c6719571a59ed