### PR TITLE
Add env example and reference in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_CLIENT_EMAIL=service-account@example.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_KEY\n-----END PRIVATE KEY-----\n"
+GOOGLE_CLIENT_EMAIL=another-service@example.iam.gserviceaccount.com
+GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_KEY\n-----END PRIVATE KEY-----\n"
+PORT=8080
+ADMIN_EMAILS=admin@example.com

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a Node.js application for managing blog posts and photo uploads 
   - `FIREBASE_PRIVATE_KEY` (escape newlines with `\n`)
   - `GOOGLE_CLIENT_EMAIL`
   - `GOOGLE_PRIVATE_KEY` (escape newlines with `\n`)
+  - see `.env.example` for an example configuration
 
 Ensure these variables are set with your own credentials before starting the application.
 


### PR DESCRIPTION
## Summary
- document environment variables in `.env.example`
- mention the new `.env.example` file under Prerequisites in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4a3944d8832aba177b7cbee93b46