### PR TITLE
Add CSRF protection using csurf

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -238,7 +238,8 @@ async function accessHashtagSheet() {
 module.exports.get_dashboard = (req, res) => {
     res.render('home', {
         pageTitle: "Dashboard",
-        hastags: hastags
+        hastags: hastags,
+        csrfToken: req.csrfToken()
     });
 }
 module.exports.get_profile = async (req, res) => {
@@ -285,7 +286,8 @@ module.exports.get_profile = async (req, res) => {
         count: dataArray.length,
         nextCursor,
         prevCursor,
-        firstKey: dataArray.length ? dataArray[0].key : null
+        firstKey: dataArray.length ? dataArray[0].key : null,
+        csrfToken: req.csrfToken()
     });
 }
 module.exports.post_upload = async (req, res) => {
@@ -427,7 +429,8 @@ module.exports.post_uploadMultiple = async (req, res) => {
     res.render('getDetails', {
         pageTitle: 'Post',
         datas: dataArray.reverse(),
-        count: dataArray.length
+        count: dataArray.length,
+        csrfToken: req.csrfToken()
     });
 };
 module.exports.get_adminDashboard = async (req, res) => {
@@ -506,7 +509,8 @@ module.exports.get_adminDashboard = async (req, res) => {
     res.render('admin/adminDashboard', {
         pageTitle: "Admin Dashboard",
         datas: data,
-        usersCount: userCount
+        usersCount: userCount,
+        csrfToken: req.csrfToken()
     });
 }
 module.exports.get_adminPhotos = async (req, res) => {
@@ -550,7 +554,8 @@ module.exports.get_adminPhotos = async (req, res) => {
         count: data.length,
         nextCursor,
         prevCursor,
-        firstKey: data.length ? data[0].key : null
+        firstKey: data.length ? data[0].key : null,
+        csrfToken: req.csrfToken()
     });
 }
 module.exports.get_adminHashtags = async (req, res) => {
@@ -572,7 +577,8 @@ module.exports.get_adminHashtags = async (req, res) => {
     res.render('admin/adminHashtags', {
         pageTitle: "Admin Dashboard",
         datas: data,
-        count: data.length
+        count: data.length,
+        csrfToken: req.csrfToken()
     });
 }
 async function updateHashtagCount(hashtag, count) {

--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -3,6 +3,7 @@ const blogController = require('../controllers/blogController');
 const { requireAuth, requireAdmin } = require('../middleware/authMiddleware');
 const multer = require('multer');
 const fastCsv = require('fast-csv');
+const csrf = require('csurf');
 
 const upload = multer({
     storage: multer.memoryStorage(),
@@ -13,6 +14,13 @@ const upload = multer({
 
 
 const router = Router();
+const csrfProtection = csrf({ cookie: true });
+
+router.use(csrfProtection);
+router.use((req, res, next) => {
+    res.locals.csrfToken = req.csrfToken();
+    next();
+});
 
 router.get('/dashboard', requireAuth, blogController.get_dashboard);
 router.post('/upload', upload.single('photo'), blogController.post_upload);

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header'); -%>
 <%- include('partials/sidebar'); -%>
+<input type="hidden" id="csrfToken" value="<%= csrfToken %>">
   <head>
     <!-- Include the necessary Firebase scripts -->
     <script src="https://www.gstatic.com/firebasejs/8.3.2/firebase-app.js"></script>
@@ -110,6 +111,7 @@
     function disableSubmitButton(form) {
       form.querySelector('button[type="submit"]').disabled = true;
     }
+    const csrfToken = document.getElementById('csrfToken').value;
     const hashtagInput = document.getElementById('hashtag-input');
     const hashtagList = document.querySelector('.hashtag-list');
     hashtagList.style.display = 'none';
@@ -207,11 +209,13 @@
       const formData = new FormData();
       formData.append('photo', image);
       formData.append('hashtags', JSON.stringify(selectedHashtagsList));
+      formData.append('_csrf', csrfToken);
       console.log(formData);
       try {
         const res = await fetch('/upload', {
           method: 'POST',
           body: formData,
+          headers: { 'CSRF-Token': csrfToken }
         });
       }
        catch (err) {
@@ -230,11 +234,13 @@
         formData.append('images', images[i]);
       }
       formData.append('hashtagsMultiple', JSON.stringify(selectedHashtagsMultipleList));
+      formData.append('_csrf', csrfToken);
       // console.log(formData);
       try {
         const res = await fetch('/upload-multiple', {
           method: 'POST',
           body: formData,
+          headers: { 'CSRF-Token': csrfToken },
         });
       }
        catch (err) {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -3,6 +3,7 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/@angular/material@latest/prebuilt-themes/indigo-pink.css" rel="stylesheet">
   <form action="/login" style="border: 2px solid #0e0d10; padding: 50px; border-radius: 6px; box-shadow: #0e0d10 2px 2px 1px 2px;">
+    <input type="hidden" id="csrfToken" name="_csrf" value="<%= csrfToken %>">
     <h2 class="none" style="border: 2px #0e0d10; background: #eef7ff; padding: 25px; font-weight: 300; box-shadow: #0e0d10 1px 1px 1px 2px; border-radius: 2px;">Login<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" style="margin-left: 10px; margin-right: 10px;" class="bi bi-toggle-off" viewBox="0 0 16 16">
       <path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8M0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5"/>
     </svg></h2>
@@ -46,6 +47,7 @@
     const form = document.querySelector('form');
     const emailError = document.querySelector('.email.error');
     const passError = document.querySelector('.password.error');
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -61,10 +63,11 @@
       firebase.auth().signInWithEmailAndPassword(email, password)
         .then(({ user }) => {
           return user.getIdToken().then((idToken) => {
-            return fetch('/login', {
+          return fetch('/login', {
               method: 'POST',
               headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'CSRF-Token': csrfToken
               },
               body: JSON.stringify({ idToken, email })
             });
@@ -91,10 +94,11 @@
         .then((result) => {
           const { user } = result;
           return user.getIdToken().then((idToken) => {
-            return fetch('/login', {
+           return fetch('/login', {
               method: 'POST',
               headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'CSRF-Token': csrfToken
               },
               body: JSON.stringify({ idToken, email: user.email })
             });

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -7,6 +7,7 @@
   <link rel="icon" src="/favicon.ico" type="favicon ico">
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/css/bootstrap.min.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
   <style>
     .navbar {
       padding-top: 20px;

--- a/views/partials/sidebar.ejs
+++ b/views/partials/sidebar.ejs
@@ -7,6 +7,7 @@
     <li><a href="/signup">Signup</a></li>
   </ul>
   <form id="sidebar-upload" action="/upload" method="POST" enctype="multipart/form-data">
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <input type="file" name="photo" required>
     <button type="submit">Upload</button>
   </form>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -2,6 +2,7 @@
 <%- include('partials/sidebar'); -%>
 
   <form action="/signup" style="border: 2px solid #0e0d10; padding: 50px; border-radius: 6px; box-shadow: #0e0d10 2px 2px 1px 2px;">
+    <input type="hidden" id="csrfToken" name="_csrf" value="<%= csrfToken %>">
     <h2 class="none" style="border: 2px #0e0d10; background: #cad3db; padding: 25px; font-weight: 300; box-shadow: #0e0d10 1px 1px 1px 2px; border-radius: 2px;">Sign up</h2>
     <label for="author">Name</label>
     <input type="text" class="form-control" name="author" required />
@@ -44,6 +45,7 @@
     const form = document.querySelector('form');
     const emailError = document.querySelector('.email.error');
     const passError = document.querySelector('.password.error');
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -61,7 +63,7 @@
         const res = await fetch('/signup', {
           method: 'POST',
           body: JSON.stringify({ email, password, author }),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken }
         });
         const data = await res.json();
         console.log(data);


### PR DESCRIPTION
## Summary
- enable csurf middleware in `blogRoutes`
- expose CSRF tokens in controller renders
- include tokens in templates and AJAX requests

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c558d13bc832aae3c51950b14e0f9