### PR TITLE
Use mounted Firebase credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ This project is a Node.js application for managing blog posts and photo uploads 
 ## Prerequisites
 
 - **Node.js**: version 20 or higher is required. You can check your version with `node --version`.
-- **Firebase configuration**: supply service account details through environment variables:
+- **Firebase configuration**: the application looks for a service account JSON
+  file mounted at `/etc/secrets/firebase-service-account-key.json`. If present,
+  it will be used automatically. When running locally, you can instead supply
+  the credentials via environment variables:
   - `FIREBASE_PROJECT_ID`
   - `FIREBASE_CLIENT_EMAIL`
   - `FIREBASE_PRIVATE_KEY` (escape newlines with `\n`)

--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -1,19 +1,39 @@
 const exifParser = require('exif-parser');
 const admin = require('firebase-admin');
-const firebaseConfig = {
-    projectId: process.env.FIREBASE_PROJECT_ID,
-    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-    privateKey: process.env.FIREBASE_PRIVATE_KEY && process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
-};
+
+let adminConfig;
+try {
+    // Prefer credentials mounted by the hosting environment
+    const serviceAccount = require('/etc/secrets/firebase-service-account-key.json');
+    adminConfig = {
+        credential: admin.credential.cert({
+            projectId: serviceAccount.project_id,
+            clientEmail: serviceAccount.client_email,
+            privateKey: serviceAccount.private_key,
+        }),
+        databaseURL: 'https://pixelate-app-e5126-default-rtdb.firebaseio.com/',
+    };
+} catch (err) {
+    // Fallback to explicit environment variables for local development/tests
+    const firebaseConfig = {
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY &&
+            process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+    };
+    adminConfig = {
+        credential: admin.credential.cert(firebaseConfig),
+        databaseURL: 'https://pixelate-app-e5126-default-rtdb.firebaseio.com/',
+    };
+}
 const { google } = require('googleapis');
 const hastags = require('../hastags.json');
 const moment = require('moment');
 const sharp = require('sharp');
 const fs = require('fs');
-admin.initializeApp({
-    credential: admin.credential.cert(firebaseConfig),
-    databaseURL: 'https://pixelate-app-e5126-default-rtdb.firebaseio.com/',
-});
+if (!admin.apps.length) {
+    admin.initializeApp(adminConfig);
+}
 const storage = admin.storage();
 const db = admin.database();
 const bucketName = 'pixelate-app-e5126.appspot.com';


### PR DESCRIPTION
## Summary
- prefer service account file from `/etc/secrets` for firebase-admin
- document mounted secret option in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5c431e78832a83e84f558512463e