### PR TITLE
Fix admin dashboard when users list empty

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -442,7 +442,8 @@ module.exports.post_uploadMultiple = async (req, res) => {
 };
 module.exports.get_adminDashboard = async (req, res) => {
     const usersRef = db.ref('users');
-    var documentNames;
+    // Initialize to an empty array so subsequent logic still runs if no users exist
+    var documentNames = [];
     await usersRef.once('value', (snapshot) => {
         if (snapshot.exists()) {
             documentNames = Object.keys(snapshot.val());


### PR DESCRIPTION
## Summary
- initialize `documentNames` with an empty array in admin dashboard controller

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6883d0e0832aacf6f473ddfd106e