### PR TITLE
Fix FocalLength property check

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -120,7 +120,7 @@ async function addDataToFirebase(data) {
             if (exifData.tags.ApertureValue) {
                 aperture = exifData.tags.ApertureValue;
             }
-            if (exifData.tags.focalLength) {
+            if (exifData.tags.FocalLength) {
                 focalLength = exifData.tags.FocalLength;
             }
             if (exifData.tags.ExposureTime) {


### PR DESCRIPTION
## Summary
- use `FocalLength` in the EXIF property check

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6884e1d4832a9c7c17df14abcf6a