### PR TITLE
Add Firebase DB rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,22 @@ This repository contains a `render.yaml` file for deploying the app to
 4. Provide any required environment variables (for example `PORT` or Firebase
    credentials) in the Render dashboard.
 5. Click **Apply** to provision the service and start the deployment.
+
+## Firebase Realtime Database Rules
+
+The repository also includes a `database.rules.json` file for the Firebase
+Realtime Database:
+
+```json
+{
+  "rules": {
+    "hashtags": { ".indexOn": ["title"] }
+  }
+}
+```
+
+Deploy these rules using the Firebase CLI:
+
+```bash
+firebase deploy --only database
+```

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "hashtags": { ".indexOn": ["title"] }
+  }
+}


### PR DESCRIPTION
## Summary
- add `database.rules.json`
- document Firebase realtime database rules and deployment via Firebase CLI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6885faa4832aa678db6c0203e8cc