### PR TITLE
Add debug secrets endpoint test

### DIFF
--- a/tests/debug.test.js
+++ b/tests/debug.test.js
@@ -1,0 +1,19 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  requireAuth: (req, res, next) => next(),
+  checkUser: (req, res, next) => next(),
+  requireAdmin: (req, res, next) => next(),
+}));
+
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /_debug/secrets', () => {
+  it('should return JSON with mounted array', async () => {
+    const res = await request(app).get('/_debug/secrets');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeDefined();
+    expect(Array.isArray(res.body.mounted)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for `_debug/secrets`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6886b4b8832aa59002119150bf05