### PR TITLE
Add Firebase hosting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Deploy these rules using the Firebase CLI:
 ```bash
 firebase deploy --only database
 ```
+
+## Firebase Hosting
+
+The `firebase.json` file configures response headers for hosting. It sets a `Content-Security-Policy` header that allows fonts loaded from `data:` URLs and scripts served from `blob:` URIs.
+
+Deploy the hosting configuration with:
+
+```bash
+firebase deploy --only hosting
+```
+

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,15 @@
+{
+  "hosting": {
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; font-src 'self' data:; script-src 'self' blob:"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- configure Firebase Hosting with CSP header
- document deploying to Firebase Hosting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6cfda2c0832ab076c02f850a67d6