### PR TITLE
Update login cookie secure option

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -77,7 +77,10 @@ module.exports.login_post = async (req, res) => {
         .createSessionCookie(idToken, { expiresIn })
         .then(
             (sessionCookie) => {
-                const options = { maxAge: expiresIn, httpOnly: true, secure: true };
+                const options = { maxAge: expiresIn, httpOnly: true };
+                if (process.env.NODE_ENV === 'production') {
+                    options.secure = true;
+                }
                 res.cookie('session', sessionCookie, options);
                 res.end(JSON.stringify({ status: 'success' }));
             },

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,59 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  requireAuth: (req, res, next) => next(),
+  checkUser: (req, res, next) => next(),
+  requireAdmin: (req, res, next) => next(),
+}));
+
+jest.mock('../controllers/blogController', () => ({
+  get_dashboard: (req, res) => res.sendStatus(200),
+  post_upload: (req, res) => res.sendStatus(200),
+  post_uploadMultiple: (req, res) => res.sendStatus(200),
+  get_profile: (req, res) => res.sendStatus(200),
+  get_postData: (req, res) => res.sendStatus(200),
+  get_adminDashboard: (req, res) => res.sendStatus(200),
+  get_adminPhotos: (req, res) => res.sendStatus(200),
+  get_adminHashtags: (req, res) => res.sendStatus(200),
+  fetchPhotos: jest.fn(() => Promise.resolve([])),
+  fetchHashtags: jest.fn(() => Promise.resolve([])),
+  fetchUsersSummary: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('firebase-admin', () => ({
+  auth: () => ({
+    createSessionCookie: jest.fn(() => Promise.resolve('fakeSession')),
+  }),
+  credential: { applicationDefault: jest.fn(), cert: jest.fn() },
+  initializeApp: jest.fn(),
+  storage: jest.fn(() => ({ bucket: jest.fn() })),
+  database: jest.fn(() => ({})),
+  apps: [],
+}));
+
+const request = require('supertest');
+const app = require('../index');
+
+describe('POST /login cookie options', () => {
+  afterEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('omits Secure attribute when not in production', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ idToken: 'abc' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['set-cookie'][0]).not.toMatch(/Secure/);
+    expect(res.headers['set-cookie'][0]).toMatch(/HttpOnly/);
+  });
+
+  it('includes Secure attribute in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const res = await request(app)
+      .post('/login')
+      .send({ idToken: 'abc' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['set-cookie'][0]).toMatch(/Secure/);
+  });
+});


### PR DESCRIPTION
## Summary
- adjust cookie `secure` flag usage in `login_post`
- add test to verify cookie options in production vs other environments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d0259ec832a8a87eb63764e696a