### PR TITLE
Fix debug secrets route

### DIFF
--- a/controllers/debugController.js
+++ b/controllers/debugController.js
@@ -4,7 +4,15 @@ const path = require('path');
 
 const router = Router();
 
-router.get('/_debug/secrets', (req, res) => {
+// Only allow debug access for admins or when not running in production
+const requireDebugAccess = (req, res, next) => {
+  if (process.env.NODE_ENV !== 'production' || res.locals.isAdmin) {
+    return next();
+  }
+  return res.status(404).end();
+};
+
+router.get('/_debug/secrets', requireDebugAccess, (req, res) => {
   const dir = '/etc/secrets';
   let mounted = [];
   const previews = {};


### PR DESCRIPTION
## Summary
- gate the `/_debug/secrets` route so it is not exposed in production unless the requester is an admin

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d00fb9c832a9caf611bf5fd0d0e