### PR TITLE
Add global CSP middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ This repository contains a `render.yaml` file for deploying the app to
    credentials) in the Render dashboard.
 5. Click **Apply** to provision the service and start the deployment.
 
+When deployed on Render, responses will not automatically include the
+`Content-Security-Policy` header defined in `firebase.json`. The middleware added
+in `index.js` sets the same policy for every request so be sure to keep it
+enabled when running on Render.
+
 ## Firebase Realtime Database Rules
 
 The repository also includes a `database.rules.json` file for the Firebase

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const blogRoutes = require('./routes/blogRoutes');
 const debugRoutes = require('./controllers/debugController');
 const cookieParser = require('cookie-parser');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
+// Content Security Policy to match firebase.json
+const CSP_VALUE = "default-src 'self'; font-src 'self' data:; script-src 'self' blob:";
 
 const app = express();
 
@@ -13,6 +15,11 @@ app.use(express.static('public'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
+// apply the same Content Security Policy as firebase hosting
+app.use((req, res, next) => {
+    res.setHeader('Content-Security-Policy', CSP_VALUE);
+    next();
+});
 app.use("/css", express.static(path.join(__dirname, "node_modules/bootstrap/dist/css")))
 app.use("/bootstrap", express.static(path.join(__dirname, "node_modules/bootstrap/dist/js")))
 app.use("/jquery", express.static(path.join(__dirname, "node_modules/jquery/dist")))


### PR DESCRIPTION
## Summary
- set a Content-Security-Policy header in Express to match `firebase.json`
- document why this middleware is needed for Render deployments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7100d660832ab7618624c5b70d2d