### PR TITLE
Update debug route tests

### DIFF
--- a/tests/debug.test.js
+++ b/tests/debug.test.js
@@ -2,7 +2,10 @@ process.env.NODE_ENV = 'test';
 
 jest.mock('../middleware/authMiddleware', () => ({
   requireAuth: (req, res, next) => next(),
-  checkUser: (req, res, next) => next(),
+  checkUser: (req, res, next) => {
+    res.locals.isAdmin = false;
+    next();
+  },
   requireAdmin: (req, res, next) => next(),
 }));
 
@@ -10,10 +13,20 @@ const request = require('supertest');
 const app = require('../index');
 
 describe('GET /_debug/secrets', () => {
+  afterEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
   it('should return JSON with mounted array', async () => {
     const res = await request(app).get('/_debug/secrets');
     expect(res.statusCode).toBe(200);
     expect(res.body).toBeDefined();
     expect(Array.isArray(res.body.mounted)).toBe(true);
+  });
+
+  it('returns 404 in production without admin privileges', async () => {
+    process.env.NODE_ENV = 'production';
+    const res = await request(app).get('/_debug/secrets');
+    expect(res.statusCode).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- mock `checkUser` to always set `res.locals.isAdmin` to `false`
- add afterEach reset of `NODE_ENV`
- add test verifying `/\_debug/secrets` returns 404 in production for non-admins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c71037864832ab570c384f6a11155