### PR TITLE
Update CSP for external fonts and styles

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; font-src 'self' data:; script-src 'self' blob:"
+            "value": "default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net; script-src 'self' https://cdn.jsdelivr.net;"
           }
         ]
       }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ const debugRoutes = require('./controllers/debugController');
 const cookieParser = require('cookie-parser');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
 // Content Security Policy to match firebase.json
-const CSP_VALUE = "default-src 'self'; font-src 'self' data:; script-src 'self' blob:";
+const CSP_VALUE = "default-src 'self'; " +
+  "font-src 'self' https://fonts.gstatic.com; " +
+  "style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
+  "script-src 'self' https://cdn.jsdelivr.net;";
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- expand content security policy to allow Google Fonts and jsDelivr
- keep identical policy in firebase hosting config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cd0130de8832a9ff51f4f2ded9d9a