### PR TITLE
Update README CSP policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ firebase deploy --only database
 
 ## Firebase Hosting
 
-The `firebase.json` file configures response headers for hosting. It sets a `Content-Security-Policy` header that allows fonts from 'self' and https://fonts.gstatic.com, styles from 'self', https://fonts.googleapis.com, https://cdn.jsdelivr.net, and scripts from 'self' and https://cdn.jsdelivr.net.
+The `firebase.json` file configures response headers for hosting. It sets a
+`Content-Security-Policy` header with these directives:
+
+- `font-src 'self' https://fonts.gstatic.com`
+- `style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net`
+- `script-src 'self' https://cdn.jsdelivr.net`
 
 Deploy the hosting configuration with:
 


### PR DESCRIPTION
## Summary
- clarify Firebase Hosting CSP directives in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ced527f44832aab58028e8f602fe6