### PR TITLE
Fix CSRF token errors on login and signup

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -41,14 +41,16 @@ const handleErrors = (err) => {
 module.exports.signup_get = (req, res) => {
     res.render('signup', {
         pageTitle: "Sign Up",
-        firebaseConfig: firebaseClientConfig
+        firebaseConfig: firebaseClientConfig,
+        csrfToken: req.csrfToken()
     });
 }
 
 module.exports.login_get = (req, res) => {
     res.render('login', {
         pageTitle: "Login",
-        firebaseConfig: firebaseClientConfig
+        firebaseConfig: firebaseClientConfig,
+        csrfToken: req.csrfToken()
     });
 }
 

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,8 +1,16 @@
 const { Router } = require('express');
 const authController = require('../controllers/authController');
+const csrf = require('csurf');
 
 
 const router = Router();
+const csrfProtection = csrf({ cookie: true });
+
+router.use(csrfProtection);
+router.use((req, res, next) => {
+    res.locals.csrfToken = req.csrfToken();
+    next();
+});
 
 router.get('/signup', authController.signup_get);
 router.post('/signup', authController.signup_post);


### PR DESCRIPTION
## Summary
- enable `csurf` middleware for authentication routes
- pass CSRF token when rendering login and signup pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf3fb68c4832a84d8083a46656142