### PR TITLE
Update CSP for gstatic scripts

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com; frame-ancestors 'none';"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com; frame-ancestors 'none';"
           }
         ]
       }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const cookieParser = require('cookie-parser');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
 // Content Security Policy to match firebase.json
 const CSP_VALUE = "default-src 'self'; " +
-  "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com; " +
+  "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com; " +
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
   "font-src 'self' data: https://fonts.gstatic.com; " +
   "img-src 'self' data: blob:; " +


### PR DESCRIPTION
## Summary
- include `https://www.gstatic.com` in the script-src directive
- keep Firebase and Express CSP policies in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfc7c6268832a8c1745a9e59a1718