### PR TITLE
Add generic error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,4 +47,10 @@ if (process.env.NODE_ENV !== 'test') {
     });
 }
 
+// generic error handler
+app.use((err, req, res, next) => {
+    console.error(err.stack);
+    res.status(500).send('Internal Server Error');
+});
+
 module.exports = app;


### PR DESCRIPTION
## Summary
- use Express generic error handler to log and respond with 500

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684cfc7d6bec832abee0fc9d80cbfdc6