### PR TITLE
Expose firebase config via module

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,14 +1,6 @@
 const admin = require('firebase-admin');
 
-const firebaseClientConfig = {
-    apiKey: process.env.FIREBASE_API_KEY,
-    authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-    projectId: process.env.FIREBASE_PROJECT_ID,
-    storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
-    appId: process.env.FIREBASE_APP_ID,
-    measurementId: process.env.FIREBASE_MEASUREMENT_ID,
-};
+const firebaseClientConfig = require('../firebaseClientConfig');
 
 const handleErrors = (err) => {
     console.error(err.message, err.code);
@@ -41,7 +33,6 @@ const handleErrors = (err) => {
 module.exports.signup_get = (req, res) => {
     res.render('signup', {
         pageTitle: "Sign Up",
-        firebaseConfig: firebaseClientConfig,
         csrfToken: req.csrfToken()
     });
 }
@@ -49,7 +40,6 @@ module.exports.signup_get = (req, res) => {
 module.exports.login_get = (req, res) => {
     res.render('login', {
         pageTitle: "Login",
-        firebaseConfig: firebaseClientConfig,
         csrfToken: req.csrfToken()
     });
 }

--- a/firebaseClientConfig.js
+++ b/firebaseClientConfig.js
@@ -1,0 +1,9 @@
+module.exports = {
+  apiKey: process.env.FIREBASE_API_KEY || '',
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN || '',
+  projectId: process.env.FIREBASE_PROJECT_ID || '',
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || '',
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID || '',
+  appId: process.env.FIREBASE_APP_ID || '',
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID || '',
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const authRoutes = require('./routes/authRoutes');
 const blogRoutes = require('./routes/blogRoutes');
 const debugRoutes = require('./controllers/debugController');
 const cookieParser = require('cookie-parser');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
+const firebaseClientConfig = require('./firebaseClientConfig');
 // Content Security Policy to match firebase.json
 const CSP_VALUE = "default-src 'self'; " +
   "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com; " +
@@ -15,6 +17,11 @@ const CSP_VALUE = "default-src 'self'; " +
   "frame-ancestors 'none';";
 
 const app = express();
+
+// generate Firebase config for client
+const configPath = path.join(__dirname, 'public', 'firebaseConfig.js');
+const configContent = 'export default ' + JSON.stringify(firebaseClientConfig, null, 2) + ';\n';
+fs.writeFileSync(configPath, configContent);
 
 // middleware
 app.use(express.static('public'));

--- a/public/firebaseConfig.js
+++ b/public/firebaseConfig.js
@@ -1,0 +1,9 @@
+export default {
+  "apiKey": "",
+  "authDomain": "",
+  "projectId": "",
+  "storageBucket": "",
+  "messagingSenderId": "",
+  "appId": "",
+  "measurementId": ""
+};

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -27,9 +27,9 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
 
-  <script>
+  <script type="module">
 
-    var firebaseConfig = <%- JSON.stringify(firebaseConfig) %>;
+    import firebaseConfig from '/firebaseConfig.js';
 
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -25,9 +25,9 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
 
-  <script>
+  <script type="module">
 
-    var firebaseConfig = <%- JSON.stringify(firebaseConfig) %>;
+    import firebaseConfig from '/firebaseConfig.js';
 
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- generate a `firebaseConfig.js` file under `public` using environment variables
- share configuration via new `firebaseClientConfig.js` module
- load this module from the views instead of embedding the config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d70940698832a8d557ac1b4ebd5a6