### PR TITLE
Add helmet CSP and test

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,8 @@ const authRoutes = require('./routes/authRoutes');
 const blogRoutes = require('./routes/blogRoutes');
 const debugRoutes = require('./controllers/debugController');
 const cookieParser = require('cookie-parser');
+const helmet = require('helmet');
 const { requireAuth, checkUser } = require('./middleware/authMiddleware');
-// Content Security Policy to match firebase.json
-const CSP_VALUE = "default-src 'self'; " +
-  "script-src 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com; " +
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
-  "font-src 'self' data: https://fonts.gstatic.com; " +
-  "img-src 'self' data: blob:; " +
-  "connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com; " +
-  "frame-ancestors 'none';";
 
 const app = express();
 
@@ -21,11 +14,38 @@ app.use(express.static('public'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
-// apply the same Content Security Policy as firebase hosting
-app.use((req, res, next) => {
-    res.setHeader('Content-Security-Policy', CSP_VALUE);
-    next();
-});
+// apply security headers including Content Security Policy
+app.use(helmet());
+app.use(
+    helmet.contentSecurityPolicy({
+        useDefaults: false,
+        directives: {
+            defaultSrc: ["'self'"],
+            scriptSrc: [
+                "'self'",
+                "'unsafe-inline'",
+                "blob:",
+                'https://cdn.jsdelivr.net',
+                'https://fonts.googleapis.com',
+                'https://www.gstatic.com',
+            ],
+            styleSrc: [
+                "'self'",
+                "'unsafe-inline'",
+                'https://fonts.googleapis.com',
+                'https://cdn.jsdelivr.net',
+            ],
+            fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
+            imgSrc: ["'self'", 'data:', 'blob:'],
+            connectSrc: [
+                "'self'",
+                'https://firestore.googleapis.com',
+                'https://*.firebaseio.com',
+            ],
+            frameAncestors: ["'none'"],
+        },
+    })
+);
 app.use("/css", express.static(path.join(__dirname, "node_modules/bootstrap/dist/css")))
 app.use("/bootstrap", express.static(path.join(__dirname, "node_modules/bootstrap/dist/js")))
 app.use("/jquery", express.static(path.join(__dirname, "node_modules/jquery/dist")))

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "fast-csv": "^4.3.6",
         "firebase-admin": "^11.11.0",
         "googleapis": "^128.0.0",
+        "helmet": "^8.1.0",
         "jquery": "^3.7.0",
         "moment": "^2.29.4",
         "multer": "^1.4.5-lts.1",
@@ -4046,6 +4047,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -10731,6 +10741,11 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fast-csv": "^4.3.6",
     "firebase-admin": "^11.11.0",
     "googleapis": "^128.0.0",
+    "helmet": "^8.1.0",
     "jquery": "^3.7.0",
     "moment": "^2.29.4",
     "multer": "^1.4.5-lts.1",

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -2,7 +2,11 @@ process.env.NODE_ENV = 'test';
 
 jest.mock('../middleware/authMiddleware', () => ({
   requireAuth: (req, res, next) => next(),
-  checkUser: (req, res, next) => next(),
+  checkUser: (req, res, next) => {
+    res.locals.user = null;
+    res.locals.isAdmin = false;
+    next();
+  },
   requireAdmin: (req, res, next) => next(),
 }));
 
@@ -60,5 +64,13 @@ describe('POST /login cookie options', () => {
       .send({ idToken: 'abc' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).toMatch(/Secure/);
+  });
+});
+
+describe('Security headers', () => {
+  it('sets the Content-Security-Policy header', async () => {
+    const res = await request(app).get('/login');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- install helmet
- enforce helmet Content Security Policy in Express app
- ensure login tests set a `user` context
- verify CSP header appears in responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d70923444832a9f5287ed3fb864ae