### PR TITLE
Allow Google services in CSP

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ app.use(
         "https://firestore.googleapis.com",
         "https://*.firebaseio.com",
         "https://identitytoolkit.googleapis.com",
+        "https://www.google-analytics.com",
+        "https://www.googleapis.com",
       ],
       "frame-ancestors": ["'none'"],
     },


### PR DESCRIPTION
## Summary
- extend Helmet CSP connect-src to include Google Analytics and Google APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7dabc954832ab66bdeb2fe98504b