### PR TITLE
Fix CSP header for static files

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,6 @@ const configContent = 'export default ' + JSON.stringify(firebaseClientConfig, n
 fs.writeFileSync(configPath, configContent);
 
 // middleware
-app.use(express.static('public'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use(cookieParser());
 app.use(
   helmet.contentSecurityPolicy({
     directives: {
@@ -56,6 +52,10 @@ app.use(
     },
   })
 );
+app.use(express.static('public'));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
 app.use("/css", express.static(path.join(__dirname, "node_modules/bootstrap/dist/css")))
 app.use("/bootstrap", express.static(path.join(__dirname, "node_modules/bootstrap/dist/js")))
 app.use("/jquery", express.static(path.join(__dirname, "node_modules/jquery/dist")))

--- a/tests/static-csp.test.js
+++ b/tests/static-csp.test.js
@@ -1,0 +1,18 @@
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const app = require('../index');
+
+describe('Content Security Policy headers on static assets', () => {
+  it('styles.css has CSP header', async () => {
+    const res = await request(app).get('/styles.css');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBeDefined();
+  });
+
+  it('downloadCSV.js has CSP header', async () => {
+    const res = await request(app).get('/downloadCSV.js');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-security-policy']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- register helmet CSP middleware before serving static files
- add tests to ensure static assets return CSP headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd109e738832a90ed99df42514943