### PR TITLE
Require auth for upload

### DIFF
--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -23,8 +23,8 @@ router.use((req, res, next) => {
 });
 
 router.get('/dashboard', requireAuth, blogController.get_dashboard);
-router.post('/upload', upload.single('photo'), blogController.post_upload);
-router.post('/upload-multiple', upload.array('images', 1000), blogController.post_uploadMultiple);
+router.post('/upload', requireAuth, upload.single('photo'), blogController.post_upload);
+router.post('/upload-multiple', requireAuth, upload.array('images', 1000), blogController.post_uploadMultiple);
 // optional query params: ?cursor=<key>&prev=<key>
 router.get('/profile', requireAuth, blogController.get_profile);
 // The personal gallery page is accessible to any authenticated user, including admins.

--- a/tests/auth-required.test.js
+++ b/tests/auth-required.test.js
@@ -1,0 +1,43 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  requireAuth: (req, res, next) => {
+    res.status(401).json({ error: 'User is not authenticated' });
+  },
+  checkUser: (req, res, next) => next(),
+  requireAdmin: (req, res, next) => next(),
+}));
+
+jest.mock('csurf', () => () => (req, res, next) => {
+  req.csrfToken = () => 'test';
+  next();
+});
+
+jest.mock('../controllers/blogController', () => ({
+  post_upload: (req, res) => res.status(200).end(),
+  post_uploadMultiple: (req, res) => res.status(200).end(),
+  fetchPhotos: jest.fn(() => Promise.resolve([])),
+  fetchHashtags: jest.fn(() => Promise.resolve([])),
+  fetchUsersSummary: jest.fn(() => Promise.resolve([])),
+  get_dashboard: (req, res) => res.sendStatus(200),
+  get_profile: (req, res) => res.sendStatus(200),
+  get_postData: (req, res) => res.sendStatus(200),
+  get_adminDashboard: (req, res) => res.sendStatus(200),
+  get_adminPhotos: (req, res) => res.sendStatus(200),
+  get_adminHashtags: (req, res) => res.sendStatus(200),
+}));
+
+const request = require('supertest');
+const app = require('../index');
+
+describe('Authentication required', () => {
+  it('POST /upload returns 401 when unauthenticated', async () => {
+    const res = await request(app).post('/upload');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('POST /upload-multiple returns 401 when unauthenticated', async () => {
+    const res = await request(app).post('/upload-multiple');
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- gate /upload and /upload-multiple behind requireAuth
- test unauthenticated upload routes return 401

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd10b24a0832aa6e592f6a0b8cce7