### PR TITLE
Enforce Firebase config via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project is a Node.js application for managing blog posts and photo uploads 
 - **Node.js**: version 20 or higher is required. You can check your version with `node --version`.
 - **Firebase configuration**: the application looks for a service account JSON
   file mounted at `/etc/secrets/firebase-service-account-key.json`. If present,
-  it will be used automatically. When running locally, you can instead supply
-  the credentials via environment variables:
+  it will be used automatically. When running locally, supply **all** Firebase
+  settings via environment variables:
   - `FIREBASE_PROJECT_ID`
   - `FIREBASE_CLIENT_EMAIL`
   - `FIREBASE_PRIVATE_KEY` (escape newlines with `\n`)
@@ -24,7 +24,8 @@ This project is a Node.js application for managing blog posts and photo uploads 
   - `FIREBASE_APP_ID`
   - `FIREBASE_MEASUREMENT_ID`
 
-Ensure these variables are set with your own credentials before starting the application.
+The application will exit during startup if any required variable is missing,
+so make sure to provide your own values before running the server.
 
 ## Installation
 

--- a/firebaseClientConfig.js
+++ b/firebaseClientConfig.js
@@ -1,9 +1,17 @@
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
 module.exports = {
-  apiKey: process.env.FIREBASE_API_KEY || 'AIzaSyBgh9RutpTDCq12QYjpnFq5B7W2PAf4X14',
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN || 'pixelate-app-e5126.firebaseapp.com',
-  projectId: process.env.FIREBASE_PROJECT_ID || 'pixelate-app-e5126',
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || 'pixelate-app-e5126.appspot.com',
-  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID || '880725228002',
-  appId: process.env.FIREBASE_APP_ID || '1:880725228002:web:6f916dddcf955c24daa1bb',
-  measurementId: process.env.FIREBASE_MEASUREMENT_ID || 'G-V4KRGLXZ1W',
+  apiKey: requireEnv('FIREBASE_API_KEY'),
+  authDomain: requireEnv('FIREBASE_AUTH_DOMAIN'),
+  projectId: requireEnv('FIREBASE_PROJECT_ID'),
+  storageBucket: requireEnv('FIREBASE_STORAGE_BUCKET'),
+  messagingSenderId: requireEnv('FIREBASE_MESSAGING_SENDER_ID'),
+  appId: requireEnv('FIREBASE_APP_ID'),
+  measurementId: requireEnv('FIREBASE_MEASUREMENT_ID'),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  setupFiles: ['<rootDir>/tests/setupEnv.js'],
 };

--- a/tests/setupEnv.js
+++ b/tests/setupEnv.js
@@ -1,0 +1,7 @@
+process.env.FIREBASE_API_KEY = 'test-api-key';
+process.env.FIREBASE_AUTH_DOMAIN = 'test.firebaseapp.com';
+process.env.FIREBASE_PROJECT_ID = 'test-project';
+process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket';
+process.env.FIREBASE_MESSAGING_SENDER_ID = 'test-sender';
+process.env.FIREBASE_APP_ID = 'test-app';
+process.env.FIREBASE_MEASUREMENT_ID = 'test-measure';


### PR DESCRIPTION
## Summary
- fail fast in `firebaseClientConfig.js` when a required Firebase env var is missing
- configure Jest to load dummy Firebase env vars for tests
- document that all Firebase settings must come from the environment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd10ce280832ab7e686492820cc69