### PR TITLE
Add login token validation

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -60,13 +60,16 @@ module.exports.signup_post = async (req, res) => {
 
 module.exports.login_post = async (req, res) => {
 
-    const idToken = req.body.idToken.toString();
+    const idToken = req.body.idToken;
+    if (!idToken) {
+        return res.status(400).json({ error: 'Missing idToken' });
+    }
 
     const expiresIn = 60 * 60 * 24 * 5 * 1000;
 
     admin
         .auth()
-        .createSessionCookie(idToken, { expiresIn })
+        .createSessionCookie(idToken.toString(), { expiresIn })
         .then(
             (sessionCookie) => {
                 const options = { maxAge: expiresIn, httpOnly: true };

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -61,4 +61,12 @@ describe('POST /login cookie options', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).toMatch(/Secure/);
   });
+
+  it('returns 400 when idToken is missing', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({});
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Missing idToken');
+  });
 });


### PR DESCRIPTION
## Summary
- validate that `idToken` is provided in `login_post`
- return `400` with message when token is missing
- test the failure case in `login.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd45fef84832ab6d362ae325d51c7