### PR TITLE
Fix hashtag update on upload error

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -302,6 +302,9 @@ module.exports.post_upload = async (req, res) => {
                     email: email
                 }
                 addDataToFirebase(data);
+                hashtagsList.forEach((hashtag) => {
+                    updateHashtagCount(hashtag, 1);
+                });
                 res.redirect('/dashboard');
             });
             uploadStream.end(resizedImageData);
@@ -310,9 +313,6 @@ module.exports.post_upload = async (req, res) => {
             logger.error('Error resizing image:', error);
             res.status(500).send('Internal Server Error');
         });
-    hashtagsList.forEach((hashtag) => {
-        updateHashtagCount(hashtag, 1);
-    });
  }
 module.exports.post_uploadMultiple = async (req, res) => {
   const files = req.files;


### PR DESCRIPTION
## Summary
- update blog controller to only update hashtag counts when upload finishes successfully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ddb318304832a904ca7343f1f14b5