### PR TITLE
Use logger for warnings/errors

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -410,7 +410,7 @@ module.exports.get_adminDashboard = async (req, res) => {
         if (snapshot.exists()) {
             documentNames = Object.keys(snapshot.val());
         } else {
-            console.warn('No documents found.');
+            logger.warn('No documents found.');
         }
     }).catch((error) => {
         logger.error('Error retrieving document names:', error);

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -103,7 +103,7 @@
           window.location.assign('/dashboard');
         })
         .catch((err) => {
-          console.error(err);
+          console.log(err);
         });
     });
   }

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -87,7 +87,7 @@ function initGoogleSignUp() {
           console.log('New user signed up:', user);
         })
         .catch((error) => {
-          console.error('Error signing up:', error);
+          console.log('Error signing up:', error);
         });
     });
   }


### PR DESCRIPTION
## Summary
- replace remaining console warnings and errors
- use the logger for reporting missing documents
- clean up console usage in client views

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddb32dd3c832aa74d027d6374a373