### PR TITLE
Fix CSP and HTML form issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `firebase.json` file configures response headers for hosting, and
 includes these directives:
 
 - `default-src 'self'`
-- `script-src-elem 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com`
+- `script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com`
 - `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net`
 - `font-src 'self' data: https://fonts.gstatic.com`
 - `img-src 'self' data: blob:`

--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src-elem 'self' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com; frame-ancestors 'none';"
+            "value": "default-src 'self'; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com; frame-ancestors 'none';"
           }
         ]
       }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ app.use(
       "script-src-elem": [
         "'self'",
         "'unsafe-inline'",
+        "'unsafe-eval'",
         "blob:",
         "https://cdn.jsdelivr.net",
         "https://fonts.googleapis.com",

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -7,11 +7,11 @@
     <h2 class="none" style="border: 2px #0e0d10; background: #eef7ff; padding: 25px; font-weight: 300; box-shadow: #0e0d10 1px 1px 1px 2px; border-radius: 2px;">Login<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" style="margin-left: 10px; margin-right: 10px;" class="bi bi-toggle-off" viewBox="0 0 16 16">
       <path d="M11 4a4 4 0 0 1 0 8H8a4.992 4.992 0 0 0 2-4 4.992 4.992 0 0 0-2-4zm-6 8a4 4 0 1 1 0-8 4 4 0 0 1 0 8M0 8a5 5 0 0 0 5 5h6a5 5 0 0 0 0-10H5a5 5 0 0 0-5 5"/>
     </svg></h2>
-    <label for="email">Email</label>
-    <input type="text" class="form-control" name="email" required />
+    <label for="email-field">Email</label>
+    <input type="text" id="email-field" class="form-control" name="email" autocomplete="email" required />
     <div class="email error"></div>
-    <label for="password">Password</label>
-    <input type="password" class="form-control" name="password" required />
+    <label for="password-field">Password</label>
+    <input type="password" id="password-field" class="form-control" name="password" autocomplete="current-password" required />
     <div class="password error"></div>
     <button class="mt-3" style="border: 1px #0e0d10; background: #9ed2ff; box-shadow: #0e0d10 1px 1px 1px 2px; border-radius: 3px;">login</button>
     <!-- Google Sign-In button -->

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -4,13 +4,13 @@
   <form action="/signup" style="border: 2px solid #0e0d10; padding: 50px; border-radius: 6px; box-shadow: #0e0d10 2px 2px 1px 2px;">
     <input type="hidden" id="csrfToken" name="_csrf" value="<%= csrfToken %>">
     <h2 class="none" style="border: 2px #0e0d10; background: #cad3db; padding: 25px; font-weight: 300; box-shadow: #0e0d10 1px 1px 1px 2px; border-radius: 2px;">Sign up</h2>
-    <label for="author">Name</label>
-    <input type="text" class="form-control" name="author" required />
-    <label for="email">Email</label>
-    <input type="text" class="form-control" name="email" required />
+    <label for="name-field">Name</label>
+    <input type="text" id="name-field" class="form-control" name="author" autocomplete="name" required />
+    <label for="email-field">Email</label>
+    <input type="text" id="email-field" class="form-control" name="email" autocomplete="email" required />
     <div class="email error"></div>
-    <label for="password">Password</label>
-    <input type="password" class="form-control" name="password" required />
+    <label for="password-field">Password</label>
+    <input type="password" id="password-field" class="form-control" name="password" autocomplete="new-password" required />
     <div class="password error"></div>
     <button class="mt-3" style="border: 1px #0e0d10; background: #458CCB; box-shadow: #0e0d10 2px 2px 1px 2px; border-radius: 3px;">Sign up</button>
  <!-- Google Sign-Up button -->


### PR DESCRIPTION
## Summary
- allow `'unsafe-eval'` in script sources
- update firebase hosting CSP to match
- document CSP change in README
- add missing `<!DOCTYPE html>`
- improve login and signup forms with ids and autocomplete attributes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb9ca822c832a9631d2446b012b7f