### PR TITLE
Fix auth module loading and CSP

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ app.use(
       "script-src-elem": [
         "'self'",
         "'unsafe-eval'",
+        "blob:",
         "https://cdn.jsdelivr.net",
         "https://cdnjs.cloudflare.com",
         "https://fonts.googleapis.com",

--- a/public/auth.js
+++ b/public/auth.js
@@ -1,7 +1,15 @@
 import firebaseConfig from './firebaseConfig.js';
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
+import {
+  getAuth,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  GoogleAuthProvider
+} from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
 
 const app = initializeApp(firebaseConfig);
+const auth = getAuth();
 
 // Attach Google authentication handlers
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -28,7 +28,7 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
-  <script src="/auth.js"></script>
+  <script type="module" src="/auth.js"></script>
 
   <script type="module">
 

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -26,7 +26,7 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
-  <script src="/auth.js"></script>
+  <script type="module" src="/auth.js"></script>
 
   <script type="module">
 


### PR DESCRIPTION
## Summary
- load `/public/auth.js` as a module in login and signup pages
- import Firebase auth helpers and initialize auth in `public/auth.js`
- include `blob:` in CSP script sources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec8afcfcc832ab72adc7d190f9e24