### PR TITLE
Fix: Add missing https://www.google.com/url?sa=E&source=gmail&q=infird.com domain to CSP

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ app.use(
         "https://www.gstatic.com",
         "https://apis.google.com",
         "https://*.firebaseio.com",
+        "https://infird.com", // This is the critical addition.
       ],
       "script-src-attr": [
         "'unsafe-inline'",
@@ -58,7 +59,7 @@ app.use(
         "'self'",
         "https://apis.google.com",
         "https://*.firebaseapp.com",
-        "https://accounts.google.com", // This is the critical addition for the pop-up.
+        "https://accounts.google.com",
       ],
       "frame-ancestors": ["'none'"],
     }


### PR DESCRIPTION
## Summary
- add `https://infird.com` to the CSP configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684edaa66834832a99eba71f0fa7d520