### PR TITLE
Fix Firestore CSP domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ app.use(
       "img-src": ["'self'", "data:", "blob:"],
       "connect-src": [
         "'self'",
-        "https.firestore.googleapis.com",
+        "https://firestore.googleapis.com",
         "https://www.googleapis.com",
         "https://identitytoolkit.googleapis.com",
         "https://*.firebaseio.com",


### PR DESCRIPTION
## Summary
- fix CSP connect-src directive for Firestore

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ee7019ae0832ab00c4cc6d10023ce