### PR TITLE
Allow eval in script-src

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com; frame-ancestors 'none';"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://fonts.googleapis.com https://www.gstatic.com https://cdnjs.cloudflare.com https://infird.com https://*.firebaseio.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com; frame-ancestors 'none';"
           }
         ]
       }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ app.use(
   helmet.contentSecurityPolicy({
     directives: {
       "default-src": ["'self'"],
-      "script-src-elem": [
+      "script-src": [
         "'self'",
         "'unsafe-inline'",
         "'unsafe-eval'",
@@ -34,6 +34,19 @@ app.use(
         "https://apis.google.com",
         "https://*.firebaseio.com",
         "https://infird.com", // This is the critical addition.
+      ],
+      "script-src-elem": [
+        "'self'",
+        "'unsafe-inline'",
+        "'unsafe-eval'",
+        "blob:",
+        "https://cdn.jsdelivr.net",
+        "https://cdnjs.cloudflare.com",
+        "https://fonts.googleapis.com",
+        "https://www.gstatic.com",
+        "https://apis.google.com",
+        "https://*.firebaseio.com",
+        "https://infird.com",
       ],
       "script-src-attr": [
         "'unsafe-inline'",
@@ -48,7 +61,7 @@ app.use(
       "img-src": ["'self'", "data:", "blob:"],
       "connect-src": [
         "'self'",
-        "https.firestore.googleapis.com",
+        "https://firestore.googleapis.com",
         "https://www.googleapis.com",
         "https://identitytoolkit.googleapis.com",
         "https://*.firebaseio.com",


### PR DESCRIPTION
## Summary
- allow eval in script-src directive

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7019ae0832ab00c4cc6d10023ce