### PR TITLE
Fix Firebase version mismatch

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,16 +1,3 @@
-import firebaseConfig from './firebaseConfig.js';
-import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
-import {
-  getAuth,
-  createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
-  signInWithPopup,
-  GoogleAuthProvider
-} from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth();
-
 // Attach Google authentication handlers
 
 const googleSignInButton = document.querySelector('#google-signin-btn');

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -28,7 +28,7 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
-  <script type="module" src="/auth.js"></script>
+  <script src="/auth.js"></script>
 
   <script type="module">
 

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -26,7 +26,7 @@
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.0.0/firebase-auth.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
-  <script type="module" src="/auth.js"></script>
+  <script src="/auth.js"></script>
 
   <script type="module">
 


### PR DESCRIPTION
## Summary
- remove unused Firebase v9 imports
- load `auth.js` as a regular script on login and signup pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ef15f3908832a9a7579d056b24a15