### PR TITLE
Enhance CSP with nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ This repository contains a `render.yaml` file for deploying the app to
    credentials) in the Render dashboard.
 5. Click **Apply** to provision the service and start the deployment.
 
-When deployed on Render, responses will not automatically include the
-`Content-Security-Policy` header defined in `firebase.json`. The middleware added
-in `index.js` sets the same policy for every request so be sure to keep it
+When deployed on Render, responses include a `Content-Security-Policy`
+header generated at runtime in `index.js`. The previous static policy in
+`firebase.json` has been removed, so ensure the middleware remains
 enabled when running on Render.
 
 ## Firebase Realtime Database Rules
@@ -95,17 +95,16 @@ firebase deploy --only database
 
 ## Firebase Hosting
 
-The `firebase.json` file configures response headers for hosting, and
-`index.js` sets the same `Content-Security-Policy` header at runtime. The policy
-includes these directives:
+The `Content-Security-Policy` header is now generated dynamically in
+`index.js` using a nonce value. An example of the directives produced at
+runtime is:
 
 - `default-src 'self'`
-- `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://www.gstatic.com https://apis.google.com https://*.firebaseio.com https://infird.com`
-- `script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://www.gstatic.com https://apis.google.com https://*.firebaseio.com https://infird.com`
-- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net`
+- `script-src 'self' 'nonce-<generated>' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://www.gstatic.com https://apis.google.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://infird.com`
+- `style-src 'self' 'nonce-<generated>' https://fonts.googleapis.com https://cdn.jsdelivr.net`
 - `font-src 'self' data: https://fonts.gstatic.com`
 - `img-src 'self' data: blob:`
-- `connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com`
+- `connect-src 'self' https://firestore.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google-analytics.com https://www.googleapis.com https://accounts.google.com`
 - `frame-src 'self' https://apis.google.com https://accounts.google.com https://*.firebaseapp.com`
 - `media-src 'self'`
 - `frame-ancestors 'none'`

--- a/firebase.json
+++ b/firebase.json
@@ -1,15 +1,4 @@
 {
   "hosting": {
-    "headers": [
-      {
-        "source": "**",
-        "headers": [
-          {
-            "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://www.gstatic.com https://apis.google.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://infird.com; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' blob: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://www.gstatic.com https://apis.google.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://infird.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self'; connect-src 'self' https://firestore.googleapis.com https://www.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://www.google-analytics.com https://accounts.google.com; frame-src 'self' https://apis.google.com https://*.firebaseapp.com https://accounts.google.com; frame-ancestors 'none';"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/views/admin/adminDashboard.ejs
+++ b/views/admin/adminDashboard.ejs
@@ -7,7 +7,7 @@
             Users
           </h4>
         <h5 class="m-0 p-0"> (<%= usersCount %>) </h5>
-        <style>
+        <style nonce="<%= cspNonce %>">
             .table tbody tr {
                 user-select: none; /* Disable text selection on table rows */
             }
@@ -56,7 +56,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.6.0"></script>
   
   <!-- Get the user data from the table -->
-  <script>
+  <script nonce="<%= cspNonce %>">
     // Get the user data from the table
     const tableRows = document.querySelectorAll('.table tbody tr');
     const users = Array.from(tableRows).map(row => {

--- a/views/admin/adminHashtags.ejs
+++ b/views/admin/adminHashtags.ejs
@@ -39,7 +39,7 @@
     </div>
     <button id="downloadButton" class="btn btn-primary mt-3">Download Data</button>
 
-    <script>
+    <script nonce="<%= cspNonce %>">
         const downloadButton = document.getElementById('downloadButton');
         downloadButton.addEventListener('click', async (event) => {
             event.preventDefault();

--- a/views/getDetails.ejs
+++ b/views/getDetails.ejs
@@ -35,7 +35,7 @@
 
 <%- include('partials/footer'); -%>
 
-<script>
+<script nonce="<%= cspNonce %>">
     const loadMoreBtn = document.getElementById('loadMoreBtn');
     let startIndex = 12; // Tracks the starting index of hidden images
     const hiddenCards = document.querySelectorAll('.col-md-4.d-none');

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -107,7 +107,7 @@
   
   <%- include('partials/tab-panel'); -%>
   <footer>&#169; House of Pixels OPC Pvt Ltd &#169;</footer>
-  <script>
+  <script nonce="<%= cspNonce %>">
     function disableSubmitButton(form) {
       form.querySelector('button[type="submit"]').disabled = true;
     }

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -30,7 +30,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
   <script src="/auth.js"></script>
 
-  <script type="module">
+  <script type="module" nonce="<%= cspNonce %>">
 
     import firebaseConfig from '/firebaseConfig.js';
 

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/css/bootstrap.min.css">
   <meta name="csrf-token" content="<%= csrfToken %>">
-  <style>
+  <style nonce="<%= cspNonce %>">
     .navbar {
       padding-top: 20px;
       padding-bottom: 20px;

--- a/views/partials/sidebar.ejs
+++ b/views/partials/sidebar.ejs
@@ -12,7 +12,7 @@
     <button type="submit">Upload</button>
   </form>
 </div>
-<script>
+<script nonce="<%= cspNonce %>">
   const sidebarToggle = document.getElementById('sidebar-toggle');
   const sidebar = document.getElementById('sidebar');
   sidebarToggle.addEventListener('click', () => {

--- a/views/partials/tab-panel.ejs
+++ b/views/partials/tab-panel.ejs
@@ -20,7 +20,7 @@
     </div>
   </div>
 </div>
-<style>
+<style nonce="<%= cspNonce %>">
   .tab-buttons {
     display: flex;
     margin-bottom: 10px;
@@ -51,7 +51,7 @@
     opacity: 1;
   }
 </style>
-<script>
+<script nonce="<%= cspNonce %>">
   document.addEventListener('DOMContentLoaded', function () {
     const links = document.querySelectorAll('.tab-link');
     const panes = document.querySelectorAll('.tab-pane');

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -28,7 +28,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
   <script src="/auth.js"></script>
 
-  <script type="module">
+  <script type="module" nonce="<%= cspNonce %>">
 
     import firebaseConfig from '/firebaseConfig.js';
 


### PR DESCRIPTION
## Summary
- generate a per-request CSP nonce and set header manually
- add nonce attribute to inline scripts and styles
- remove static CSP header from firebase config
- update README with new policy description
- check nonce in CSP unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a484d9cd0832a8f55173788e1f5b0