### PR TITLE
Add auth input validation

### DIFF
--- a/middleware/validationMiddleware.js
+++ b/middleware/validationMiddleware.js
@@ -1,0 +1,34 @@
+const { body, validationResult } = require('express-validator');
+
+const validateSignup = [
+  body('email').isEmail().withMessage('Invalid email format'),
+  body('password')
+    .isLength({ min: 6 })
+    .withMessage('Password must be at least 6 characters long'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    next();
+  },
+];
+
+const validateLogin = [
+  body('email').isEmail().withMessage('Invalid email format'),
+  body('password')
+    .isLength({ min: 6 })
+    .withMessage('Password must be at least 6 characters long'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    next();
+  },
+];
+
+module.exports = {
+  validateSignup,
+  validateLogin,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ejs": "^3.1.9",
         "exif-parser": "^0.1.12",
         "express": "^4.18.2",
+        "express-validator": "^7.2.1",
         "fast-csv": "^4.3.6",
         "firebase-admin": "^13.4.0",
         "googleapis": "^128.0.0",
@@ -3236,6 +3237,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -5284,6 +5298,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -7588,6 +7608,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ejs": "^3.1.9",
     "exif-parser": "^0.1.12",
     "express": "^4.18.2",
+    "express-validator": "^7.2.1",
     "fast-csv": "^4.3.6",
     "firebase-admin": "^13.4.0",
     "googleapis": "^128.0.0",

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,5 +1,9 @@
 const { Router } = require('express');
 const authController = require('../controllers/authController');
+const {
+  validateSignup,
+  validateLogin,
+} = require('../middleware/validationMiddleware');
 
 
 // ... other code ...
@@ -10,10 +14,10 @@ const authController = require('../controllers/authController');
 const router = Router();
 
 router.get('/signup', authController.signup_get);
-router.post('/signup', authController.signup_post);
+router.post('/signup', validateSignup, authController.signup_post);
 router.get('/', authController.login_get);
 router.get('/login', authController.login_get);
-router.post('/login', authController.login_post);
+router.post('/login', validateLogin, authController.login_post);
 router.get('/logout', authController.logout_get);
 
 module.exports = router;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -47,7 +47,7 @@ describe('POST /login cookie options', () => {
   it('omits Secure attribute when not in production', async () => {
     const res = await request(app)
       .post('/login')
-      .send({ idToken: 'abc' });
+      .send({ idToken: 'abc', email: 'test@example.com', password: 'abcdef' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).not.toMatch(/Secure/);
     expect(res.headers['set-cookie'][0]).toMatch(/HttpOnly/);
@@ -57,7 +57,7 @@ describe('POST /login cookie options', () => {
     process.env.NODE_ENV = 'production';
     const res = await request(app)
       .post('/login')
-      .send({ idToken: 'abc' });
+      .send({ idToken: 'abc', email: 'test@example.com', password: 'abcdef' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).toMatch(/Secure/);
   });
@@ -65,7 +65,7 @@ describe('POST /login cookie options', () => {
   it('returns 400 when idToken is missing', async () => {
     const res = await request(app)
       .post('/login')
-      .send({});
+      .send({ email: 'test@example.com', password: 'abcdef' });
     expect(res.statusCode).toBe(400);
     expect(res.body.error).toBe('Missing idToken');
   });


### PR DESCRIPTION
## Summary
- install `express-validator`
- validate login and signup fields
- test login route with email and password

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6887867d0804832abacfe80317bfe5e0