### PR TITLE
Add COOKIE_SECURE flag for login cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ FIREBASE_STORAGE_BUCKET=your-app.appspot.com
 FIREBASE_MESSAGING_SENDER_ID=your-sender-id
 FIREBASE_APP_ID=your-app-id
 FIREBASE_MEASUREMENT_ID=your-measurement-id
+COOKIE_SECURE=false

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -73,8 +73,8 @@ module.exports.login_post = async (req, res) => {
         .createSessionCookie(idToken.toString(), { expiresIn })
         .then(
             (sessionCookie) => {
-                const options = { maxAge: expiresIn, httpOnly: true };
-                if (process.env.NODE_ENV === 'production') {
+                const options = { maxAge: expiresIn, httpOnly: true, sameSite: 'lax' };
+                if (process.env.COOKIE_SECURE === 'true') {
                     options.secure = true;
                 }
                 res.cookie('session', sessionCookie, options);

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,4 +1,5 @@
 process.env.NODE_ENV = 'test';
+process.env.COOKIE_SECURE = 'false';
 
 jest.mock('../middleware/authMiddleware', () => ({
   requireAuth: (req, res, next) => next(),
@@ -42,24 +43,28 @@ const app = require('../index');
 describe('POST /login cookie options', () => {
   afterEach(() => {
     process.env.NODE_ENV = 'test';
+    process.env.COOKIE_SECURE = 'false';
   });
 
-  it('omits Secure attribute when not in production', async () => {
+  it('omits Secure attribute when COOKIE_SECURE is false', async () => {
     const res = await request(app)
       .post('/login')
       .send({ idToken: 'abc' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).not.toMatch(/Secure/);
     expect(res.headers['set-cookie'][0]).toMatch(/HttpOnly/);
+    expect(res.headers['set-cookie'][0]).toMatch(/SameSite=Lax/);
   });
 
-  it('includes Secure attribute in production', async () => {
-    process.env.NODE_ENV = 'production';
+  it('includes Secure attribute when COOKIE_SECURE is true', async () => {
+    process.env.COOKIE_SECURE = 'true';
     const res = await request(app)
       .post('/login')
       .send({ idToken: 'abc' });
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie'][0]).toMatch(/Secure/);
+    expect(res.headers['set-cookie'][0]).toMatch(/HttpOnly/);
+    expect(res.headers['set-cookie'][0]).toMatch(/SameSite=Lax/);
   });
 
   it('returns 400 when idToken is missing', async () => {

--- a/tests/setupEnv.js
+++ b/tests/setupEnv.js
@@ -7,3 +7,4 @@ process.env.FIREBASE_APP_ID = 'test-app';
 process.env.FIREBASE_MEASUREMENT_ID = 'test-measure';
 process.env.CSRF_SECRET = '12345678901234567890123456789012';
 process.env.COOKIE_SECRET = 'cookie-secret';
+process.env.COOKIE_SECURE = 'false';


### PR DESCRIPTION
## Summary
- allow configuring cookie Secure flag via `COOKIE_SECURE`
- set `HttpOnly` and `SameSite=Lax` on login cookie
- extend login tests for new flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68878680c28c832aaa20cc398af980fc