### PR TITLE
Atomic hashtag update

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -553,33 +553,27 @@ async function updateHashtagCount(hashtag, count) {
     await hashtagCountsRef.orderByChild("title").equalTo(hashtag).once('value')
         .then((snapshot) => {
             snapshot.forEach((childSnapshot) => {
-                const currentCount = parseInt(childSnapshot.val().count) || 0;
-                // Increment the count by 1
+                const data = childSnapshot.val();
+                const currentCount = parseInt(data.count) || 0;
+                const currentTokens = parseFloat(data.utilityTokensLocked) || 0;
+
                 const newCount = currentCount + count;
-                // Update the count field
-                childSnapshot.ref.update({
-                    count: newCount.toString()
-                });
-                const newAvg = parseInt(childSnapshot.val().utilityTokensLocked) / newCount;
-                // Update the Average field
-                childSnapshot.ref.update({
-                    avgPrice: newAvg.toString()
-                });
+                let newTokens = currentTokens;
+
                 const prev = parseInt(currentCount / 100);
                 const x = parseInt(newCount / 100);
                 const diff = x - prev;
                 if (diff) {
-                    const currentTokens = parseFloat(childSnapshot.val().utilityTokensLocked) || 0;
-                    const newTokens = currentTokens + diff * 10000;
-                    childSnapshot.ref.update({
-                        utilityTokensLocked: newTokens.toString()
-                    });
-                    const newAverage = newTokens / newCount;
-                    // Update the Average field
-                    childSnapshot.ref.update({
-                        avgPrice: newAverage.toString()
-                    });
+                    newTokens += diff * 10000;
                 }
+
+                const newAvg = newTokens / newCount;
+
+                childSnapshot.ref.update({
+                    count: newCount.toString(),
+                    utilityTokensLocked: newTokens.toString(),
+                    avgPrice: newAvg.toString(),
+                });
             })
         })
 }
@@ -674,3 +668,4 @@ async function fetchUsersSummary() {
 module.exports.fetchPhotos = fetchPhotos;
 module.exports.fetchHashtags = fetchHashtags;
 module.exports.fetchUsersSummary = fetchUsersSummary;
+module.exports.updateHashtagCount = updateHashtagCount;

--- a/tests/update-hashtag-count.test.js
+++ b/tests/update-hashtag-count.test.js
@@ -1,0 +1,42 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('firebase-admin', () => {
+  const updateMock = jest.fn();
+  const onceMock = jest.fn();
+  const equalToMock = jest.fn(() => ({ once: onceMock }));
+  const orderByChildMock = jest.fn(() => ({ equalTo: equalToMock }));
+  const refMock = jest.fn(() => ({ orderByChild: orderByChildMock }));
+
+  return {
+    credential: { applicationDefault: jest.fn(), cert: jest.fn() },
+    initializeApp: jest.fn(),
+    storage: jest.fn(() => ({ bucket: jest.fn() })),
+    database: jest.fn(() => ({ ref: refMock })),
+    apps: [],
+    __mocks: { updateMock, onceMock, equalToMock, orderByChildMock, refMock },
+  };
+});
+
+const admin = require('firebase-admin');
+const { updateHashtagCount } = require('../controllers/blogController');
+
+describe('updateHashtagCount', () => {
+  it('updates all fields atomically', async () => {
+    const { updateMock, onceMock } = admin.__mocks;
+    onceMock.mockResolvedValue({
+      forEach: (cb) => cb({
+        val: () => ({ count: '99', utilityTokensLocked: '0' }),
+        ref: { update: updateMock },
+      }),
+    });
+
+    await updateHashtagCount('tag1', 2);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith({
+      count: '101',
+      utilityTokensLocked: '10000',
+      avgPrice: (10000 / 101).toString(),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- compute hashtag counts and price calculations before update
- send update to Firebase in a single call
- export `updateHashtagCount` for testing
- add unit test covering atomic update logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887868180b8832a8dd6a214a98131a8