### PR TITLE
Improve CSP policy and add nonce tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ app.use((req, res, next) => {
     `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com https://cdn.jsdelivr.net`,
     "img-src 'self' data: blob:",
     "font-src 'self' data: https://fonts.gstatic.com",
-    "connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://www.googleapis.com https://*.firebaseio.com https://www.google-analytics.com https://accounts.google.com",
+    "connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://*.firebaseio.com https://www.google-analytics.com https://accounts.google.com",
     "frame-src 'self' https://apis.google.com https://accounts.google.com https://*.firebaseapp.com",
     "frame-ancestors 'none'",
     "media-src 'self'",

--- a/tests/csp-pages.test.js
+++ b/tests/csp-pages.test.js
@@ -1,0 +1,39 @@
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+
+jest.mock('../middleware/authMiddleware', () => ({
+  requireAuth: (req, res, next) => next(),
+  checkUser: (req, res, next) => { res.locals.isAdmin = false; res.locals.user = null; next(); },
+  requireAdmin: (req, res, next) => next(),
+}));
+
+jest.mock('csurf', () => () => (req, res, next) => { req.csrfToken = () => 'test'; next(); });
+
+const app = require('../index');
+
+function parseCsp(header) {
+  return header.split(';').reduce((acc, part) => {
+    const trimmed = part.trim();
+    if (!trimmed) return acc;
+    const [name, ...values] = trimmed.split(/\s+/);
+    acc[name] = values;
+    return acc;
+  }, {});
+}
+
+describe('CSP headers on pages', () => {
+  const routes = ['/login', '/signup', '/dashboard'];
+  routes.forEach(route => {
+    it(`${route} has nonce in CSP`, async () => {
+      const res = await request(app).get(route);
+      expect(res.statusCode).toBe(200);
+      const csp = res.headers['content-security-policy'];
+      expect(csp).toBeDefined();
+      const directives = parseCsp(csp);
+      expect(directives['script-src']).toBeDefined();
+      const nonce = directives['script-src'].find(v => v.startsWith("'nonce-"));
+      expect(nonce).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend `connect-src` with Firebase secure token domain
- ensure pages return CSP nonce via new Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688915549740832ab6e98be9a9b90c27