### PR TITLE
Move inline styles to stylesheet

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -311,3 +311,64 @@ footer {
 .icon-folder { margin: 20px; background-color: #FFD752; padding: 10px; border-radius: 25px; box-shadow: inset -1px 1px 3px 0px; }
 .card-title-custom { font-variant-caps: all-petite-caps; font-weight: 900; font-size: xx-large; }
 .card-text-custom { background-color: #cbefcf; box-shadow: inset -1px 1px 2px #1c1c1c; border-radius: 4px; padding: 4px; }
+/* Header styles extracted from EJS */
+.navbar {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  border-radius: 10px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #0e0d10;
+  margin-bottom: 25px;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.navbar-nav {
+  display: flex;
+  justify-content: center;
+}
+
+.nav-item {
+  margin-right: 15px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #0e0d10;
+  border-radius: 5px;
+}
+
+/* Tab panel styles extracted from EJS */
+.tab-buttons {
+  display: flex;
+  margin-bottom: 10px;
+}
+.tab-link {
+  margin-right: 5px;
+  padding: 6px 12px;
+  border: 1px solid #0e0d10;
+  background-color: #A3C6E5;
+  color: #0e0d10;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+.tab-link.active {
+  background-color: #0e0d10;
+  color: #A3C6E5;
+}
+.tab-pane {
+  display: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  border: 1px solid #0e0d10;
+  padding: 10px;
+  border-radius: 4px;
+}
+.tab-pane.active {
+  display: block;
+  opacity: 1;
+}
+
+/* Admin dashboard styles extracted from EJS */
+.table tbody tr {
+  user-select: none;
+}

--- a/views/admin/adminDashboard.ejs
+++ b/views/admin/adminDashboard.ejs
@@ -7,11 +7,6 @@
             Users
           </h4>
         <h5 class="m-0 p-0"> (<%= usersCount %>) </h5>
-        <style nonce="<%= cspNonce %>">
-            .table tbody tr {
-                user-select: none; /* Disable text selection on table rows */
-            }
-        </style>
         <h3>
             <button id="downloadButton" class="btn btn-primary">Download Data</button>
             <script src="/downloadCSV.js"></script>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -9,36 +9,6 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/vendor/css/bootstrap.min.css">
   <meta name="csrf-token" content="<%= csrfToken %>">
-  <style nonce="<%= cspNonce %>">
-    .navbar {
-      padding-top: 20px;
-      padding-bottom: 20px;
-      border-radius: 10px;
-      border-style: solid;      
-      border-width: 1px;
-      border-color: #0e0d10;
-      margin-bottom: 25px;
-      margin-left: 5px;
-      margin-right: 5px;
-
-    }
-    
-
-    .navbar-nav {
-      display: flex;
-      justify-content: center;
-   
-    }
-
-    .nav-item {
-      margin-right: 15px;
-      border-width: 1px;
-      border-style: solid;
-      border-color: #0e0d10;
-      border-radius: 5px;
-    }
-
-  </style>
   <script src="/vendor/js/jquery.min.js"></script>
   <script src="/vendor/js/bootstrap.bundle.min.js"></script>
 </head>

--- a/views/partials/tab-panel.ejs
+++ b/views/partials/tab-panel.ejs
@@ -20,37 +20,6 @@
     </div>
   </div>
 </div>
-<style nonce="<%= cspNonce %>">
-  .tab-buttons {
-    display: flex;
-    margin-bottom: 10px;
-  }
-  .tab-link {
-    margin-right: 5px;
-    padding: 6px 12px;
-    border: 1px solid #0e0d10;
-    background-color: #A3C6E5;
-    color: #0e0d10;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-  }
-  .tab-link.active {
-    background-color: #0e0d10;
-    color: #A3C6E5;
-  }
-  .tab-pane {
-    display: none;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    border: 1px solid #0e0d10;
-    padding: 10px;
-    border-radius: 4px;
-  }
-  .tab-pane.active {
-    display: block;
-    opacity: 1;
-  }
-</style>
 <script nonce="<%= cspNonce %>">
   document.addEventListener('DOMContentLoaded', function () {
     const links = document.querySelectorAll('.tab-link');


### PR DESCRIPTION
## Summary
- extract custom navbar, tab, and dashboard styles from EJS templates
- add the extracted rules to `public/styles.css`
- remove inline `<style>` blocks

## Testing
- `npm install`
- `npm test`
- `npm start` *(server started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_68898b4b8bc4832a85de1393bab8ce4a